### PR TITLE
fix compatibility with latest dokuwiki

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -26,7 +26,7 @@ class renderer_plugin_linkprefix extends Doku_Renderer_xhtml {
 		return false;
 	}
 
-	function externallink($url, $name = NULL) {
+	function externallink($url, $name = null, $returnonly = false) {
 		if (!$this->getConf('prefix') || $this->getConf('ignore_same_domain') == 1 && strtolower(parse_url($url, PHP_URL_HOST)) == strtolower($_SERVER["HTTP_HOST"])) {
 			return parent::externallink($url, $name);
 		}
@@ -43,7 +43,7 @@ class renderer_plugin_linkprefix extends Doku_Renderer_xhtml {
 		return parent::externallink($url, $name);
 	}
 
-	function _resolveInterWiki($shortcut,$reference){
+	function _resolveInterWiki(&$shortcut, $reference, &$exists = null) {
 		if (!$this->getConf('prefix')) {
 			return parent::_resolveInterWiki($shortcut,$reference);
 		}


### PR DESCRIPTION
Fix declaration error with latest Dokuwiki version.

```
PHP Warning:  Declaration of renderer_plugin_linkprefix0:0:0:0:0:0:0:0_resolveInterWiki($shortcut, $reference) should be compatible with Doku_Renderer0:0:0:0:0:0:0:0_resolveInterWiki(&$shortcut, $reference, &$exists = NULL) in /var/www/dokuwiki/lib/plugins/linkprefix/renderer.php on line 16
PHP Warning:  Declaration of renderer_plugin_linkprefix0:0:0:0:0:0:0:0xternallink($url, $name = NULL) should be compatible with Doku_Renderer_xhtml0:0:0:0:0:0:0:0xternallink($url, $name = NULL, $returnonly = false) in /var/www/dokuwiki/lib/plugins/linkprefix/renderer.php on line 16
```